### PR TITLE
Add Jumbucks support

### DIFF
--- a/core/src/main/java/com/coinomi/core/coins/CoinID.java
+++ b/core/src/main/java/com/coinomi/core/coins/CoinID.java
@@ -38,6 +38,7 @@ public enum CoinID {
     DIGIBYTE_MAIN(DigibyteMain.get()),
     NEOSCOIN_MAIN(NeoscoinMain.get()),
     NEOSCOIN_TEST(NeoscoinTest.get())
+    JUMBUCKS_MAIN(JumbucksMain.get()),
     ;
 
     private static List<CoinType> types;

--- a/core/src/main/java/com/coinomi/core/coins/JumbucksMain.java
+++ b/core/src/main/java/com/coinomi/core/coins/JumbucksMain.java
@@ -1,0 +1,32 @@
+package com.coinomi.core.coins;
+
+import org.bitcoinj.core.Coin;
+
+/**
+ * @author Julian Yap
+ */
+public class JumbucksMain extends CoinType {
+    private JumbucksMain() {
+        id = "jumbucks.main";
+
+        addressHeader = 43;
+        p2shHeader = 105;
+        acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
+        spendableCoinbaseDepth = 500;
+
+        name = "Jumbucks";
+        symbol = "JBS";
+        uriScheme = "jumbucks";
+        bip44Index = 26;
+        unitExponent = 8;
+        feePerKb = value(10000); // 0.0001 JBS
+        minNonDust = value(1);
+        softDustLimit = value(1000000); // 0.01 JBS
+        softDustPolicy = SoftDustPolicy.AT_LEAST_BASE_FEE_IF_SOFT_DUST_TXO_PRESENT;
+    }
+
+    private static JumbucksMain instance = new JumbucksMain();
+    public static synchronized JumbucksMain get() {
+        return instance;
+    }
+}

--- a/wallet/src/main/java/com/coinomi/wallet/Constants.java
+++ b/wallet/src/main/java/com/coinomi/wallet/Constants.java
@@ -24,6 +24,7 @@ import com.coinomi.core.coins.ReddcoinMain;
 import com.coinomi.core.coins.RubycoinMain;
 import com.coinomi.core.coins.UroMain;
 import com.coinomi.core.coins.NeoscoinMain;
+import com.coinomi.core.coins.JumbucksMain;
 //import com.coinomi.core.coins.NeoscoinTest;
 import com.coinomi.core.network.CoinAddress;
 import com.coinomi.stratumj.ServerAddress;
@@ -168,6 +169,7 @@ public class Constants {
         COINS_ICONS.put(CoinID.CANNACOIN_MAIN.getCoinType(), R.drawable.cannacoin);
         COINS_ICONS.put(CoinID.DIGIBYTE_MAIN.getCoinType(), R.drawable.digibyte);
         COINS_ICONS.put(CoinID.NEOSCOIN_MAIN.getCoinType(), R.drawable.neoscoin);
+        COINS_ICONS.put(CoinID.JUMBUCKS_MAIN.getCoinType(), R.drawable.jumbucks);
 
         COINS_BLOCK_EXPLORERS = new HashMap<CoinType, String>();
         COINS_BLOCK_EXPLORERS.put(CoinID.BITCOIN_MAIN.getCoinType(), "https://blockchain.info/tx/%s");
@@ -192,6 +194,7 @@ public class Constants {
         COINS_BLOCK_EXPLORERS.put(CoinID.CANNACOIN_MAIN.getCoinType(), "https://chainz.cryptoid.info/ccn/tx.dws?%s");
         COINS_BLOCK_EXPLORERS.put(CoinID.DIGIBYTE_MAIN.getCoinType(), "https://digiexplorer.info/tx/%s");
         COINS_BLOCK_EXPLORERS.put(CoinID.NEOSCOIN_MAIN.getCoinType(), "http://explorer.infernopool.com/tx/%s");
+        COINS_BLOCK_EXPLORERS.put(CoinID.JUMBUCKS_MAIN.getCoinType(), "http://explorer.getjumbucks.com/tx/%s");
     }
 
     public static final CoinType DEFAULT_COIN = BitcoinMain.get();
@@ -219,6 +222,7 @@ public class Constants {
             DigitalcoinMain.get(),
             CannacoinMain.get(),
             NeoscoinMain.get(),
+            JumbucksMain.get(),
             BitcoinTest.get(),
             LitecoinTest.get(),
             DogecoinTest.get()


### PR DESCRIPTION
Jumbucks can use the same family as:
org.bitcoinj.params.Networks.Family.BLACKCOIN

Electrum server settings are (use the Blackcoin branch):
```
[network]
pubkey_address = 43
script_address = 105
genesis_hash = 0000018b17ebb6160e2ce6162b68c7a63ad5fd146d376e7c976ed41b614ce692
[bitcoind]
bitcoind_port = 51716
```

This change has been committed to the Jumbucks source code:
https://github.com/jyap808/jumbucks/commit/bb7add5aeb917026c9e9ad43de840c44cce399e6

Thanks!
